### PR TITLE
Change CI workflow into separate jobs

### DIFF
--- a/.github/workflows/create-ephemeral-environment.yml
+++ b/.github/workflows/create-ephemeral-environment.yml
@@ -1,8 +1,5 @@
-# This is a basic workflow to help you get started with Actions
+name: Build docker image and release with Octopus
 
-name: Create New Ephemeral Environment in Octopus
-
-# Controls when the workflow will run
 on:
   push:
     branches: ["main"]
@@ -23,10 +20,9 @@ env:
   IMAGE_NAME: OctopusDeployTesting/dad-joker-2000
   OCTOPUS_SPACE: Demo
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
-    name: Create new release
+    name: Build and push docker image
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}
@@ -65,7 +61,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: "Login to Container Registry"
+      - name: Login to Container Registry
         run: |
           az acr login --name ${{ env.REGISTRY_NAME }}
 
@@ -93,7 +89,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  deploy_test_environment:
+  test_environment:
     name: Deploy to test environment
     needs: build
     runs-on: ubuntu-latest
@@ -138,8 +134,8 @@ jobs:
           server_task_id: ${{ fromJSON(steps.deploy_step.outputs.server_tasks)[0].serverTaskId }}
           polling_interval: 2s
 
-  deploy_production:
-    name: Deploy to production
+  production:
+    name: Create production release and tag repo
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/create-ephemeral-environment.yml
+++ b/.github/workflows/create-ephemeral-environment.yml
@@ -25,9 +25,11 @@ env:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  job:
+  build:
     name: Create new release
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -91,18 +93,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Tag repo on main branch
-        uses: actions/github-script@v6.3.3
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/v${{ steps.get_release_version.outputs.version }}',
-              sha: context.sha
-            })
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-
+  deploy_test_environment:
+    name: Deploy to test environment
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
       - name: Login to Octopus Deploy
         uses: OctopusDeploy/login@v1
         with:
@@ -110,49 +106,67 @@ jobs:
           service_account_id: ${{ secrets.OCTOPUS_SERVICE_ACCOUNT_ID }}
 
       - name: Create test environment
-        if: github.event_name == 'pull_request'
         uses: OctopusDeploy/create-ephemeral-environment@v1.0.0
         with:
           name: pr-${{ github.event.pull_request.number }}
           project: Dad Joker 2000
 
       - name: Create test environment release
-        if: github.event_name == 'pull_request'
         uses: OctopusDeploy/create-release-action@v3
         with:
           project: Dad Joker 2000
-          release_number: ${{ steps.get_version.outputs.version }}
+          release_number: ${{ needs.build.outputs.version }}
           channel: Test environments
           git_ref: ${{ github.head_ref }}
           git_commit: ${{ github.event.pull_request.head.sha }}
-          package_version: ${{ steps.get_version.outputs.version }}
+          package_version: ${{ needs.build.outputs.version }}
           custom_fields: |
             PullRequestNumber: ${{ github.event.pull_request.number }}
 
       - name: Deploy the test environment release
         id: deploy_step
-        if: github.event_name == 'pull_request'
         uses: OctopusDeploy/deploy-release-action@v3
         with:
           project: Dad Joker 2000
-          release_number: ${{ steps.get_version.outputs.version }}
+          release_number: ${{ needs.build.outputs.version }}
           environments: |
             pr-${{ github.event.pull_request.number }}
 
       - name: Wait for deployment to complete
-        if: github.event_name == 'pull_request'
         uses: OctopusDeploy/await-task-action@v3
         with:
           server_task_id: ${{ fromJSON(steps.deploy_step.outputs.server_tasks)[0].serverTaskId }}
           polling_interval: 2s
 
+  deploy_production:
+    name: Deploy to production
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - name: Login to Octopus Deploy
+        uses: OctopusDeploy/login@v1
+        with:
+          server: ${{ secrets.OCTOPUS_SERVER_URL }}
+          service_account_id: ${{ secrets.OCTOPUS_SERVICE_ACCOUNT_ID }}
+
       - name: Create production release
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: OctopusDeploy/create-release-action@v3
         with:
           project: Dad Joker 2000
-          release_number: ${{ steps.get_version.outputs.version }}
+          release_number: ${{ needs.build.outputs.version }}
           channel: Production
           git_ref: ${{ github.ref }}
           git_commit: ${{ github.sha }}
-          package_version: ${{ steps.get_version.outputs.version }}
+          package_version: ${{ needs.build.outputs.version }}
+
+      - name: Tag repo on main branch
+        uses: actions/github-script@v6.3.3
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v${{ needs.build.outputs.version }}',
+              sha: context.sha
+            })


### PR DESCRIPTION
Changes the CI workflow to use separate jobs for PRs vs main builds to make it a little clearer to view